### PR TITLE
[UNBLOCKER] #53: Phase 1: Remove agent labels when PR is created to properly free agents

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -953,6 +953,17 @@ async fn handle_landing_phase(client: &github::GitHubClient, phase: LandingPhase
                             Ok(pr_url) => {
                                 println!("✅ PR created: {}", pr_url);
                                 
+                                // Remove agent label from issue to free the agent in system status
+                                match remove_label_from_issue(client, issue_number, &agent_id).await {
+                                    Ok(_) => {
+                                        println!("🏷️  Removed agent label '{}' from issue #{}", agent_id, issue_number);
+                                    }
+                                    Err(e) => {
+                                        println!("⚠️  Failed to remove agent label '{}': {:?}", agent_id, e);
+                                        println!("   Agent still functionally freed, but status may show incorrect capacity");
+                                    }
+                                }
+                                
                                 // Switch back to main branch to free the agent
                                 let _ = Command::new("git")
                                     .args(&["checkout", "main"])


### PR DESCRIPTION
## Summary
## Problem
After Phase 1 PR creation, agent labels remain on GitHub issues causing clambake status to incorrectly show agents as 'AT CAPACITY' even though they're freed and on main branch.


## Changes Made
- 1 commit(s) implementing the solution
- Changes ready for review and integration

## Test Plan  
- [x] Code compiles and builds successfully
- [x] Changes tested locally
- [x] Ready for code review

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of agent availability/capacity indicators after a PR is created by automatically clearing the agent-specific label from the related issue.
  * Added error handling and user-facing warnings if label cleanup fails, reducing chances of stale status information.
  * No changes to the PR creation or branch-switch workflow; overall reliability improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->