### PR TITLE
Fix: Document correct enum usage in fetch_open_pull_requests

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -341,6 +341,8 @@ impl GitHubClient {
         let pulls = self.octocrab
             .pulls(&self.owner, &self.repo)
             .list()
+            // Note: octocrab::params::State::Open is correct here, not octocrab::params::pulls::State::Open
+            // The .state() method expects octocrab::params::State, as verified by compilation
             .state(octocrab::params::State::Open)
             .send()
             .await?;


### PR DESCRIPTION
## Summary
- Investigated CodeRabbit suggestion about incorrect enum usage
- Found that the original code using `octocrab::params::State::Open` is correct
- Added clarifying comment to prevent future confusion

## Details
CodeRabbit suggested changing `octocrab::params::State::Open` to `octocrab::params::pulls::State::Open`, but testing revealed the original code is correct. The `.state()` method on the pulls list builder expects `octocrab::params::State`, not the pulls-specific enum.

## Test plan
- [x] Verified original code compiles without errors
- [x] Confirmed suggested change causes compilation failure
- [x] Added documentation to clarify correct usage

Fixes #62

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added clarifying comments in the GitHub integration around pull request state parameters to improve maintainability. No functional changes.

- Chores
  - No changes to public APIs.
  - Behavior, performance, and runtime remain unchanged.
  - Low review effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->