### PR TITLE
Add professional badges to README for quick project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Clambake
 
+[![Property-Based Tests](https://github.com/johnhkchen/clambake/actions/workflows/property-tests.yml/badge.svg)](https://github.com/johnhkchen/clambake/actions/workflows/property-tests.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/johnhkchen/clambake)
+[![Rust](https://img.shields.io/badge/rust-1.75%2B-orange.svg)](https://www.rust-lang.org/)
+[![Status](https://img.shields.io/badge/status-Early%20Alpha-red.svg)](https://github.com/johnhkchen/clambake)
+
 Turn GitHub Issues into a job queue for AI coding agents—coordinate multiple autonomous developers working on your repository simultaneously.
 
 **Development Status: Early Alpha**  


### PR DESCRIPTION
## Summary
- Add build status badge linking to GitHub Actions workflow
- Add MIT license badge with link to license details  
- Add version badge showing current release (0.1.0)
- Add Rust version requirement badge (1.75+)
- Add development status badge (Early Alpha)

## Test plan
- [x] Verify all badge URLs are functional
- [x] Confirm badge information matches project state
- [x] Ensure visual elements enhance rather than clutter
- [x] Validate badges provide immediate project health information

Resolves #192

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with five status badges: Property-Based Tests, License (MIT), Version (0.1.0), Rust compatibility (1.75+), and project status (Early Alpha).
  * Adds a blank line after the badges for improved readability.
  * Improves at-a-glance project context (testing approach, licensing, required Rust version, maturity) on the repository homepage.
  * No code, behavior, or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->